### PR TITLE
adding RTL support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - yarn install
 
 script:
-  - yarn test --passWithNoTests
+  - yarn test
 
 before_deploy: "echo starting deploy!"
 deploy:

--- a/README.md
+++ b/README.md
@@ -22,4 +22,6 @@ Tech used:
 Future steps:
 
 - [ ] Add docker support
-- [ ] Add unit/integrtion tests with RTL (react-testing-library)
+- [x] Add unit/integrtion tests with RTL (react-testing-library)
+- [ ] Add virtual / infinite scroll
+- [ ] Add CSS grid for listing pokemons

--- a/package.json
+++ b/package.json
@@ -37,5 +37,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^4.0.0",
+    "@testing-library/react": "^8.0.7"
   }
 }

--- a/src/components/AttacksTable.tsx
+++ b/src/components/AttacksTable.tsx
@@ -22,7 +22,7 @@ export const AttacksTable = ({ title, attacks }: AttacksTableProps) => (
       </thead>
       <TableBody>
         {attacks.map((el: AttackType) => (
-          <tr>
+          <tr key={`${el.name} - ${el.damage}`}>
             <AttackName>{el.name}</AttackName>
             <td>
               <TypeTag value={el.type} />

--- a/src/components/PokemonFrontCard.tsx
+++ b/src/components/PokemonFrontCard.tsx
@@ -29,8 +29,8 @@ export const PokemonFrontCard = ({
       </Trapeizoid>
       <ContentBox>
         <TagWrapper>
-          {types.map(value => (
-            <TypeTag value={value} />
+          {types.map((value, i) => (
+            <TypeTag key={`${value} - ${i}`} value={value} />
           ))}
         </TagWrapper>
         <NameWrapper>{name}</NameWrapper>

--- a/src/components/__tests__/AttacksTable.test.jsx
+++ b/src/components/__tests__/AttacksTable.test.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { AttacksTable } from "../AttacksTable";
+
+const props = {
+  attacks: [
+    {
+      damage: 12,
+      name: "fast-attack-1",
+      type: "Normal"
+    },
+    {
+      damage: 123,
+      name: "fast-attack-2",
+      type: "Normal"
+    },
+    {
+      damage: 1234,
+      name: "fast-attack-3",
+      type: "Normal"
+    }
+  ],
+  title: "Fast Attacks"
+};
+
+describe("<AttacksTable />", () => {
+  it("matches the snapshot", () => {
+    const wrapper = render(<AttacksTable {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+  it("has two normal type tag attacks", () => {
+    const { getAllByText } = render(<AttacksTable {...props} />);
+    const normalTypeAttack = getAllByText("Normal");
+    expect(normalTypeAttack).toHaveLength(3);
+  });
+});

--- a/src/components/__tests__/MaxStatBox.test.jsx
+++ b/src/components/__tests__/MaxStatBox.test.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { MaxStatBox } from "../MaxStatBox";
+
+const props = {
+  text: "max cp",
+  value: 456
+};
+
+describe("<MaxStatBox />", () => {
+  it("matches the snapshot", () => {
+    const wrapper = render(<MaxStatBox {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/components/__tests__/PokemonBackCard.test.jsx
+++ b/src/components/__tests__/PokemonBackCard.test.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { PokemonBackCard } from "../PokemonBackCard";
+
+const props = {
+  onClick: jest.fn(),
+  attacks: {
+    fast: [
+      {
+        damage: 123,
+        name: "foo",
+        type: "Grass"
+      }
+    ],
+    special: [
+      {
+        damage: 123,
+        name: "bar",
+        type: "Normal"
+      }
+    ]
+  },
+  maxCP: 123,
+  maxHP: 123
+};
+
+describe("<PokemonBackCard />", () => {
+  it("matches the snapshot", () => {
+    const wrapper = render(<PokemonBackCard {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/components/__tests__/PokemonCard.test.jsx
+++ b/src/components/__tests__/PokemonCard.test.jsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react";
+import { PokemonCard } from "../PokemonCard";
+
+const props = {
+  attacks: {
+    fast: [
+      {
+        damage: 12,
+        name: "fast-attack-1",
+        type: "Normal"
+      }
+    ],
+    special: [
+      {
+        damage: 12,
+        name: "special-attack-1",
+        type: "Normal"
+      }
+    ]
+  },
+  maxCP: 123,
+  maxHP: 123,
+  name: "bulbasaur",
+  number: "001",
+  types: ["Gras,poison"]
+};
+
+describe("<PokemonCard />", () => {
+  it("matches the snapshot", () => {
+    const wrapper = render(<PokemonCard {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+  it("initially should display the front card containning the pokemon image", () => {
+    const { getByAltText } = render(<PokemonCard {...props} />);
+    expect(getByAltText(`pokemon ${props.name}`)).toBeTruthy();
+  });
+  it("clicking on the pokemon should toggle the front and back cards", () => {
+    const { getByAltText, container, getByText } = render(
+      <PokemonCard {...props} />
+    );
+    const frontCard = getByAltText(`pokemon ${props.name}`);
+    expect(frontCard).toBeTruthy();
+    fireEvent.click(frontCard, container);
+    const backCard = getByText("MAX CP");
+    expect(backCard).toBeTruthy();
+  });
+});

--- a/src/components/__tests__/TypeTag.test.jsx
+++ b/src/components/__tests__/TypeTag.test.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { TypeTag } from "../TypeTag";
+
+const props = {
+  value: "Normal"
+};
+
+describe("<TypeTag />", () => {
+  it("matches the snapshot", () => {
+    const wrapper = render(<TypeTag {...props} />);
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/components/__tests__/__snapshots__/AttacksTable.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/AttacksTable.test.jsx.snap
@@ -1,0 +1,228 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<AttacksTable /> matches the snapshot 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <span
+        class="sc-gZMcBi ijIzWX"
+      >
+        Fast Attacks
+      </span>
+      <table
+        class="sc-dnqmqq eTxSPZ"
+      >
+        <thead>
+          <tr>
+            <th
+              class="sc-VigVT jQzTgw"
+            >
+              Attack
+            </th>
+            <th>
+              Type
+            </th>
+            <th>
+              Power
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="sc-iwsKbI bRezmp"
+        >
+          <tr>
+            <td
+              class="sc-gqjmRU bBzpNg"
+            >
+              fast-attack-1
+            </td>
+            <td>
+              <span
+                class="sc-gzVnrw fxNcuu"
+                color="#A8A878"
+              >
+                Normal
+              </span>
+            </td>
+            <td>
+              12
+            </td>
+          </tr>
+          <tr>
+            <td
+              class="sc-gqjmRU bBzpNg"
+            >
+              fast-attack-2
+            </td>
+            <td>
+              <span
+                class="sc-gzVnrw fxNcuu"
+                color="#A8A878"
+              >
+                Normal
+              </span>
+            </td>
+            <td>
+              123
+            </td>
+          </tr>
+          <tr>
+            <td
+              class="sc-gqjmRU bBzpNg"
+            >
+              fast-attack-3
+            </td>
+            <td>
+              <span
+                class="sc-gzVnrw fxNcuu"
+                color="#A8A878"
+              >
+                Normal
+              </span>
+            </td>
+            <td>
+              1234
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </body>,
+  "container": <div>
+    <span
+      class="sc-gZMcBi ijIzWX"
+    >
+      Fast Attacks
+    </span>
+    <table
+      class="sc-dnqmqq eTxSPZ"
+    >
+      <thead>
+        <tr>
+          <th
+            class="sc-VigVT jQzTgw"
+          >
+            Attack
+          </th>
+          <th>
+            Type
+          </th>
+          <th>
+            Power
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class="sc-iwsKbI bRezmp"
+      >
+        <tr>
+          <td
+            class="sc-gqjmRU bBzpNg"
+          >
+            fast-attack-1
+          </td>
+          <td>
+            <span
+              class="sc-gzVnrw fxNcuu"
+              color="#A8A878"
+            >
+              Normal
+            </span>
+          </td>
+          <td>
+            12
+          </td>
+        </tr>
+        <tr>
+          <td
+            class="sc-gqjmRU bBzpNg"
+          >
+            fast-attack-2
+          </td>
+          <td>
+            <span
+              class="sc-gzVnrw fxNcuu"
+              color="#A8A878"
+            >
+              Normal
+            </span>
+          </td>
+          <td>
+            123
+          </td>
+        </tr>
+        <tr>
+          <td
+            class="sc-gqjmRU bBzpNg"
+          >
+            fast-attack-3
+          </td>
+          <td>
+            <span
+              class="sc-gzVnrw fxNcuu"
+              color="#A8A878"
+            >
+              Normal
+            </span>
+          </td>
+          <td>
+            1234
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/src/components/__tests__/__snapshots__/MaxStatBox.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/MaxStatBox.test.jsx.snap
@@ -1,0 +1,84 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<MaxStatBox /> matches the snapshot 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="sc-fjdhpX egTBPK"
+      >
+        max cp
+        <div
+          class="sc-jTzLTM joxsON"
+        >
+          456
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="sc-fjdhpX egTBPK"
+    >
+      max cp
+      <div
+        class="sc-jTzLTM joxsON"
+      >
+        456
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/src/components/__tests__/__snapshots__/PokemonBackCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/PokemonBackCard.test.jsx.snap
@@ -1,0 +1,304 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<PokemonBackCard /> matches the snapshot 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <section
+        class="sc-bwzfXH pcdvo"
+      >
+        <div
+          class="sc-htoDjs kaRscw"
+        >
+          <div
+            class="sc-fjdhpX egTBPK"
+          >
+            MAX CP
+            <div
+              class="sc-jTzLTM joxsON"
+            >
+              123
+            </div>
+          </div>
+          <div
+            class="sc-fjdhpX egTBPK"
+          >
+            MAX HP
+            <div
+              class="sc-jTzLTM joxsON"
+            >
+              123
+            </div>
+          </div>
+        </div>
+        <span
+          class="sc-gZMcBi ijIzWX"
+        >
+          Fast Attacks
+        </span>
+        <table
+          class="sc-dnqmqq eTxSPZ"
+        >
+          <thead>
+            <tr>
+              <th
+                class="sc-VigVT jQzTgw"
+              >
+                Attack
+              </th>
+              <th>
+                Type
+              </th>
+              <th>
+                Power
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            class="sc-iwsKbI bRezmp"
+          >
+            <tr>
+              <td
+                class="sc-gqjmRU bBzpNg"
+              >
+                foo
+              </td>
+              <td>
+                <span
+                  class="sc-gzVnrw cTGLyP"
+                  color="#78C850"
+                >
+                  Grass
+                </span>
+              </td>
+              <td>
+                123
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <span
+          class="sc-gZMcBi ijIzWX"
+        >
+          Special Attacks
+        </span>
+        <table
+          class="sc-dnqmqq eTxSPZ"
+        >
+          <thead>
+            <tr>
+              <th
+                class="sc-VigVT jQzTgw"
+              >
+                Attack
+              </th>
+              <th>
+                Type
+              </th>
+              <th>
+                Power
+              </th>
+            </tr>
+          </thead>
+          <tbody
+            class="sc-iwsKbI bRezmp"
+          >
+            <tr>
+              <td
+                class="sc-gqjmRU bBzpNg"
+              >
+                bar
+              </td>
+              <td>
+                <span
+                  class="sc-gzVnrw fxNcuu"
+                  color="#A8A878"
+                >
+                  Normal
+                </span>
+              </td>
+              <td>
+                123
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </div>
+  </body>,
+  "container": <div>
+    <section
+      class="sc-bwzfXH pcdvo"
+    >
+      <div
+        class="sc-htoDjs kaRscw"
+      >
+        <div
+          class="sc-fjdhpX egTBPK"
+        >
+          MAX CP
+          <div
+            class="sc-jTzLTM joxsON"
+          >
+            123
+          </div>
+        </div>
+        <div
+          class="sc-fjdhpX egTBPK"
+        >
+          MAX HP
+          <div
+            class="sc-jTzLTM joxsON"
+          >
+            123
+          </div>
+        </div>
+      </div>
+      <span
+        class="sc-gZMcBi ijIzWX"
+      >
+        Fast Attacks
+      </span>
+      <table
+        class="sc-dnqmqq eTxSPZ"
+      >
+        <thead>
+          <tr>
+            <th
+              class="sc-VigVT jQzTgw"
+            >
+              Attack
+            </th>
+            <th>
+              Type
+            </th>
+            <th>
+              Power
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="sc-iwsKbI bRezmp"
+        >
+          <tr>
+            <td
+              class="sc-gqjmRU bBzpNg"
+            >
+              foo
+            </td>
+            <td>
+              <span
+                class="sc-gzVnrw cTGLyP"
+                color="#78C850"
+              >
+                Grass
+              </span>
+            </td>
+            <td>
+              123
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <span
+        class="sc-gZMcBi ijIzWX"
+      >
+        Special Attacks
+      </span>
+      <table
+        class="sc-dnqmqq eTxSPZ"
+      >
+        <thead>
+          <tr>
+            <th
+              class="sc-VigVT jQzTgw"
+            >
+              Attack
+            </th>
+            <th>
+              Type
+            </th>
+            <th>
+              Power
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class="sc-iwsKbI bRezmp"
+        >
+          <tr>
+            <td
+              class="sc-gqjmRU bBzpNg"
+            >
+              bar
+            </td>
+            <td>
+              <span
+                class="sc-gzVnrw fxNcuu"
+                color="#A8A878"
+              >
+                Normal
+              </span>
+            </td>
+            <td>
+              123
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/src/components/__tests__/__snapshots__/PokemonCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/PokemonCard.test.jsx.snap
@@ -1,0 +1,140 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<PokemonCard /> matches the snapshot 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <section
+        class="sc-bwzfXH pcdvo"
+      >
+        <img
+          alt="pokemon bulbasaur"
+          class="sc-bdVaJa eDZiWC"
+          src="https://assets.pokemon.com/assets/cms2/img/pokedex/full/001.png"
+        />
+        <div
+          class="sc-htpNat isyJfG"
+        >
+          <span
+            class="sc-EHOje kwEFtJ"
+          >
+            #
+            001
+          </span>
+        </div>
+        <div
+          class="sc-bZQynM bjRqD"
+        >
+          <div
+            class="sc-bxivhb fvCTiD"
+          >
+            <span
+              class="sc-gzVnrw ioRBds"
+              color="#68A090"
+            >
+              Gras,poison
+            </span>
+          </div>
+          <div
+            class="sc-ifAKCX ESkqv"
+          >
+            bulbasaur
+          </div>
+        </div>
+      </section>
+    </div>
+  </body>,
+  "container": <div>
+    <section
+      class="sc-bwzfXH pcdvo"
+    >
+      <img
+        alt="pokemon bulbasaur"
+        class="sc-bdVaJa eDZiWC"
+        src="https://assets.pokemon.com/assets/cms2/img/pokedex/full/001.png"
+      />
+      <div
+        class="sc-htpNat isyJfG"
+      >
+        <span
+          class="sc-EHOje kwEFtJ"
+        >
+          #
+          001
+        </span>
+      </div>
+      <div
+        class="sc-bZQynM bjRqD"
+      >
+        <div
+          class="sc-bxivhb fvCTiD"
+        >
+          <span
+            class="sc-gzVnrw ioRBds"
+            color="#68A090"
+          >
+            Gras,poison
+          </span>
+        </div>
+        <div
+          class="sc-ifAKCX ESkqv"
+        >
+          bulbasaur
+        </div>
+      </div>
+    </section>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/src/components/__tests__/__snapshots__/TypeTag.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/TypeTag.test.jsx.snap
@@ -1,0 +1,76 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<TypeTag /> matches the snapshot 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <span
+        class="sc-gzVnrw fxNcuu"
+        color="#A8A878"
+      >
+        Normal
+      </span>
+    </div>
+  </body>,
+  "container": <div>
+    <span
+      class="sc-gzVnrw fxNcuu"
+      color="#A8A878"
+    >
+      Normal
+    </span>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,2 @@
+// this is basically: afterEach(cleanup)
+import "@testing-library/react/cleanup-after-each";

--- a/src/utils/__tests__/index.test.js
+++ b/src/utils/__tests__/index.test.js
@@ -1,0 +1,19 @@
+import { pokemonTagType, imageUrlFromPokemonId } from "../index";
+
+describe("pokemonTagType", () => {
+  it("returns the correct hex color according to the pokemon type if correctly identified", () => {
+    expect(pokemonTagType("Normal")).toEqual("#A8A878");
+  });
+  it("returns the fallback option in case the type is not listed", () => {
+    expect(pokemonTagType("????")).toEqual("#68A090");
+  });
+});
+
+describe("imageUrlFromPokemonId", () => {
+  it("fetches the img based on the pokemon id", () => {
+    const id = 5;
+    const result =
+      "https://assets.pokemon.com/assets/cms2/img/pokedex/full/5.png";
+    expect(imageUrlFromPokemonId(id)).toEqual(result);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -859,6 +859,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.5.1", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
+  integrity sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.1.0", "@babel/template@^7.4.0", "@babel/template@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
@@ -1112,6 +1119,11 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
+"@sheerun/mutationobserver-shim@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
+  integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
+
 "@svgr/babel-plugin-add-jsx-attribute@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz#dadcb6218503532d6884b210e7f3c502caaa44b1"
@@ -1216,6 +1228,40 @@
     "@svgr/plugin-jsx" "^4.1.0"
     "@svgr/plugin-svgo" "^4.0.3"
     loader-utils "^1.1.0"
+
+"@testing-library/dom@^5.5.4":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-5.6.1.tgz#705a1cb4a039b877c1e69e916824038e837ab637"
+  integrity sha512-Y1T2bjtvQMewffn1CJ28kpgnuvPYKsBcZMagEH0ppfEMZPDc8AkkEnTk4smrGZKw0cblNB3lhM2FMnpfLExlHg==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    "@sheerun/mutationobserver-shim" "^0.3.2"
+    aria-query "3.0.0"
+    pretty-format "^24.8.0"
+    wait-for-expect "^1.2.0"
+
+"@testing-library/jest-dom@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-4.0.0.tgz#56eee8dd183fe14a682fda7aca6413ec4e5303d2"
+  integrity sha512-YQA/LnRRfqHV5YRauawOGgMDgq43XfyqCz3whmxIPyrfvTdjLCNyY/BseGaa48y54yb3oiRo/NZT0oXNMQdkTA==
+  dependencies:
+    "@babel/runtime" "^7.5.1"
+    chalk "^2.4.1"
+    css "^2.2.3"
+    css.escape "^1.5.1"
+    jest-diff "^24.0.0"
+    jest-matcher-utils "^24.0.0"
+    lodash "^4.17.11"
+    pretty-format "^24.0.0"
+    redent "^3.0.0"
+
+"@testing-library/react@^8.0.7":
+  version "8.0.7"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-8.0.7.tgz#b5992c9156e926850a0e3a7c882ae1aed83b1c77"
+  integrity sha512-6XoeWSr3UCdxMswbkW0BmuXYw8a6w+stt+5gg4D4zAcljfhXETQ5o28bjJFwNab4OPg8gBNK8KIVot86L4Q8Vg==
+  dependencies:
+    "@babel/runtime" "^7.5.4"
+    "@testing-library/dom" "^5.5.4"
 
 "@types/babel__core@^7.1.0":
   version "7.1.1"
@@ -1820,7 +1866,7 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-aria-query@^3.0.0:
+aria-query@3.0.0, aria-query@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
   integrity sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=
@@ -3119,6 +3165,21 @@ css-what@2.1, css-what@^2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
+
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
+css@^2.2.3:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
+  integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
+  dependencies:
+    inherits "^2.0.3"
+    source-map "^0.6.1"
+    source-map-resolve "^0.5.2"
+    urix "^0.1.0"
 
 cssdb@^4.3.0:
   version "4.4.0"
@@ -4915,6 +4976,11 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
 indexes-of@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
@@ -5418,7 +5484,7 @@ jest-config@^24.8.0:
     pretty-format "^24.8.0"
     realpath-native "^1.1.0"
 
-jest-diff@^24.8.0:
+jest-diff@^24.0.0, jest-diff@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-24.8.0.tgz#146435e7d1e3ffdf293d53ff97e193f1d1546172"
   integrity sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==
@@ -5531,7 +5597,7 @@ jest-leak-detector@^24.8.0:
   dependencies:
     pretty-format "^24.8.0"
 
-jest-matcher-utils@^24.8.0:
+jest-matcher-utils@^24.0.0, jest-matcher-utils@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz#2bce42204c9af12bde46f83dc839efe8be832495"
   integrity sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==
@@ -6335,6 +6401,11 @@ mimic-fn@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+min-indent@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.0.tgz#cfc45c37e9ec0d8f0a0ec3dd4ef7f7c3abe39256"
+  integrity sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=
 
 mini-css-extract-plugin@0.5.0:
   version "0.5.0"
@@ -7873,7 +7944,7 @@ pretty-error@^2.1.1:
     renderkid "^2.0.1"
     utila "~0.4"
 
-pretty-format@^24.8.0:
+pretty-format@^24.0.0, pretty-format@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.8.0.tgz#8dae7044f58db7cb8be245383b565a963e3c27f2"
   integrity sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==
@@ -8305,6 +8376,14 @@ recursive-readdir@2.2.2:
   integrity sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==
   dependencies:
     minimatch "3.0.4"
+
+redent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
+  integrity sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+  dependencies:
+    indent-string "^4.0.0"
+    strip-indent "^3.0.0"
 
 regenerate-unicode-properties@^8.0.2:
   version "8.0.2"
@@ -8926,7 +9005,7 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-source-map-resolve@^0.5.0:
+source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
   integrity sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==
@@ -9208,6 +9287,13 @@ strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
   integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
+
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
 
 strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
@@ -9862,6 +9948,11 @@ w3c-xmlserializer@^1.1.2:
     domexception "^1.0.1"
     webidl-conversions "^4.0.2"
     xml-name-validator "^3.0.0"
+
+wait-for-expect@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.2.0.tgz#fdab6a26e87d2039101db88bff3d8158e5c3e13f"
+  integrity sha512-EJhKpA+5UHixduMBEGhTFuLuVgQBKWxkFbefOdj2bbk2/OpA5Opsc4aUTGmF+qJ+v3kTGxDRNYwKaT4j6g5n8Q==
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
This Pull request adds the usage of `React-testing-library` for testing user interaction rather than code implementation.

It also:
- fix travis playbook 
- add components unit/integration tests
- adds a readme 'next steps'


This PR add the following `dev` dependencies:
```
    "@testing-library/jest-dom": "^4.0.0",
    "@testing-library/react": "^8.0.7"
```